### PR TITLE
Contact page with customizable email subject

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -16,4 +16,4 @@ Please feel free to contact us.
 
 ## Email us via the contact form below
 
-{{< contact_subject >}}
+{{< contact_subject email_subject="[General Inquiry]: " >}}

--- a/layouts/shortcodes/contact_subject.html
+++ b/layouts/shortcodes/contact_subject.html
@@ -1,17 +1,20 @@
-{{ $text := or (.Get "text") "" }}
+{{ $email_subject := or (.Get "email_subject") "" }}
 <script>
     // Prepopulate contact form from URL query parameters
     document.addEventListener('DOMContentLoaded', function() {
         var urlParams = new URLSearchParams(window.location.search)
         var urlSubject = urlParams.get('subject')
-        var subject = urlSubject !== null ? urlSubject : {{ $text | jsonify }}
-        
+        var subject = urlSubject !== null ? urlSubject : {{ $email_subject }}
+                // console.log({'email_subject':{{ $email_subject }}, urlSubject:urlSubject, subject:subject})
+
         // Populate the subject field if we have a value
         if (subject) {
             var subjectField = document.getElementById('subject')
             if (subjectField) {
                 // Decode URL-encoded value if it came from URL params
-                subjectField.value = urlSubject !== null ? decodeURIComponent(subject) : subject
+                new_subject = urlSubject !== null ? decodeURIComponent(subject) : subject
+                // console.log({new_subject: new_subject})
+                subjectField.value = new_subject;
             }
         }
     })


### PR DESCRIPTION
Usage:

In the markdown, use the shortcode
```markdown
{{< contact_subject >}}                    <!-- No default, uses empty string if no URL param -->
{{< contact_subject text="General Inquiry" >}}  <!-- Uses "General Inquiry" if no URL param -->
```

The latter populates the contact form with the subject line with `General Inquiry`. 

From a browser, use URL encoded parameters ```http://..../contact/?subject=%5BCall%20catalogue%5D%3A%20``` which will populate the subject line with `[Call catalogue]: `